### PR TITLE
apply-rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
@@ -30,7 +32,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
 end
 
 group :development do
@@ -38,8 +40,8 @@ group :development do
   gem 'web-console', '>= 4.1.0'
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  gem 'rack-mini-profiler', '~> 2.0'
   gem 'listen', '~> 3.3'
+  gem 'rack-mini-profiler', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 end
@@ -53,4 +55,4 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative "config/application"
+require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
+# ArticlesController class
 class ArticlesController < ApplicationController
-  http_basic_authenticate_with name: "julian", password: "secret", except: [:index, :show]
+  http_basic_authenticate_with name: 'julian', password: 'secret', except: %i[index show]
   def index
     @articles = Article.all
   end
@@ -11,7 +14,7 @@ class ArticlesController < ApplicationController
 
   # C methods (CRUD)
   def new
-    @article =Article.new
+    @article = Article.new
   end
 
   def create
@@ -48,8 +51,8 @@ class ArticlesController < ApplicationController
   end
 
   private
+
   def article_params
     params.require(:article).permit(:title, :body, :status)
   end
-
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CommentsController < ApplicationController
   http_basic_authenticate_with name: "julian", password: "secret", only: :destroy
   def create

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
+# CommentsController class
 class CommentsController < ApplicationController
-  http_basic_authenticate_with name: "julian", password: "secret", only: :destroy
+  http_basic_authenticate_with name: 'julian', password: 'secret', only: :destroy
   def create
     @article = Article.find(params[:article_id])
     @comment = @article.comments.create(comment_params)
@@ -16,6 +17,7 @@ class CommentsController < ApplicationController
   end
 
   private
+
   def comment_params
     params.require(:comment).permit(:commenter, :body, :status)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# ApplicationHelper module
 module ApplicationHelper
 end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# ArticlesHelper module
 module ArticlesHelper
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
+# CommentsHelper module
 module CommentsHelper
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# ApplicationRecord class
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Article < ApplicationRecord
   include Visible
   has_many :comments, dependent: :destroy

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Comment < ApplicationRecord
   include Visible
   belongs_to :article

--- a/app/models/concerns/visible.rb
+++ b/app/models/concerns/visible.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
+# Visible module
 module Visible
   extend ActiveSupport::Concern
 
-  VALID_STATUSES = ['public', 'private', 'archived']
+  VALID_STATUSES = %w[public private archived].freeze
 
   included do
     validates :status, inclusion: { in: VALID_STATUSES }

--- a/bin/bundle
+++ b/bin/bundle
@@ -8,46 +8,46 @@
 # this file is here to facilitate running it.
 #
 
-require "rubygems"
+require 'rubygems'
 
 m = Module.new do
   module_function
 
   def invoked_as_script?
-    File.expand_path($0) == File.expand_path(__FILE__)
+    File.expand_path($PROGRAM_NAME) == File.expand_path(__FILE__)
   end
 
   def env_var_version
-    ENV["BUNDLER_VERSION"]
+    ENV['BUNDLER_VERSION']
   end
 
   def cli_arg_version
     return unless invoked_as_script? # don't want to hijack other binstubs
-    return unless "update".start_with?(ARGV.first || " ") # must be running `bundle update`
+    return unless 'update'.start_with?(ARGV.first || ' ') # must be running `bundle update`
+
     bundler_version = nil
     update_index = nil
     ARGV.each_with_index do |a, i|
-      if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
-        bundler_version = a
-      end
+      bundler_version = a if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
       next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
-      bundler_version = $1
+
+      bundler_version = Regexp.last_match(1)
       update_index = i
     end
     bundler_version
   end
 
   def gemfile
-    gemfile = ENV["BUNDLE_GEMFILE"]
+    gemfile = ENV['BUNDLE_GEMFILE']
     return gemfile if gemfile && !gemfile.empty?
 
-    File.expand_path("../../Gemfile", __FILE__)
+    File.expand_path('../Gemfile', __dir__)
   end
 
   def lockfile
     lockfile =
       case File.basename(gemfile)
-      when "gems.rb" then gemfile.sub(/\.rb$/, gemfile)
+      when 'gems.rb' then gemfile.sub(/\.rb$/, gemfile)
       else "#{gemfile}.lock"
       end
     File.expand_path(lockfile)
@@ -55,15 +55,17 @@ m = Module.new do
 
   def lockfile_version
     return unless File.file?(lockfile)
+
     lockfile_contents = File.read(lockfile)
     return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+
     Regexp.last_match(1)
   end
 
   def bundler_version
     @bundler_version ||=
       env_var_version || cli_arg_version ||
-        lockfile_version
+      lockfile_version
   end
 
   def bundler_requirement
@@ -73,29 +75,30 @@ m = Module.new do
 
     requirement = bundler_gem_version.approximate_recommendation
 
-    return requirement unless Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.7.2")
+    return requirement unless Gem::Version.new(Gem::VERSION) < Gem::Version.new('2.7.2')
 
-    requirement += ".a" if bundler_gem_version.prerelease?
+    requirement += '.a' if bundler_gem_version.prerelease?
 
     requirement
   end
 
   def load_bundler!
-    ENV["BUNDLE_GEMFILE"] ||= gemfile
+    ENV['BUNDLE_GEMFILE'] ||= gemfile
 
     activate_bundler
   end
 
   def activate_bundler
-    gem_error = activation_error_handling do
-      gem "bundler", bundler_requirement
-    end
+    gem_error = activation_error_handling { gem 'bundler', bundler_requirement }
     return if gem_error.nil?
-    require_error = activation_error_handling do
-      require "bundler/version"
+
+    require_error = activation_error_handling { require 'bundler/version' }
+    if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
+      return
     end
-    return if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
-    warn "Activating bundler (#{bundler_requirement}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_requirement}'`"
+
+    warn "Activating bundler (#{bundler_requirement}) failed:\n#{gem_error.message}\n
+    To install the version of bundler this project requires, run `gem install bundler -v '#{bundler_requirement}'`"
     exit 42
   end
 
@@ -109,6 +112,4 @@ end
 
 m.load_bundler!
 
-if m.invoked_as_script?
-  load Gem.bin_path("bundler", "bundle")
-end
+load Gem.bin_path('bundler', 'bundle') if m.invoked_as_script?

--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
-load File.expand_path("spring", __dir__)
+# frozen_string_literal: true
+
+load File.expand_path('spring', __dir__)
 APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative "../config/boot"
-require "rails/commands"
+require_relative '../config/boot'
+require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
-load File.expand_path("spring", __dir__)
-require_relative "../config/boot"
-require "rake"
+# frozen_string_literal: true
+
+load File.expand_path('spring', __dir__)
+require_relative '../config/boot'
+require 'rake'
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
-require "fileutils"
+# frozen_string_literal: true
+
+require 'fileutils'
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)

--- a/bin/spring
+++ b/bin/spring
@@ -1,13 +1,15 @@
 #!/usr/bin/env ruby
-if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
-  gem "bundler"
-  require "bundler"
+# frozen_string_literal: true
+
+if !defined?(Spring) && [nil, 'development', 'test'].include?(ENV['RAILS_ENV'])
+  gem 'bundler'
+  require 'bundler'
 
   # Load Spring without loading other gems in the Gemfile, for speed.
-  Bundler.locked_gems&.specs&.find { |spec| spec.name == "spring" }&.tap do |spring|
+  Bundler.locked_gems&.specs&.find { |spec| spec.name == 'spring' }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem "spring", spring.version
-    require "spring/binstub"
+    gem 'spring', spring.version
+    require 'spring/binstub'
   rescue Gem::LoadError
     # Ignore when Spring is not installed.
   end

--- a/bin/webpack
+++ b/bin/webpack
@@ -1,18 +1,19 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV['RAILS_ENV'] ||= ENV['RACK_ENV'] || 'development'
+ENV['NODE_ENV']  ||= 'development'
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile',
+                                           Pathname.new(__FILE__).realpath)
 
-require "bundler/setup"
+require 'bundler/setup'
 
-require "webpacker"
-require "webpacker/webpack_runner"
+require 'webpacker'
+require 'webpacker/webpack_runner'
 
-APP_ROOT = File.expand_path("..", __dir__)
+APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   Webpacker::WebpackRunner.run(ARGV)
 end

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -1,18 +1,19 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV['RAILS_ENV'] ||= ENV['RACK_ENV'] || 'development'
+ENV['NODE_ENV']  ||= 'development'
 
-require "pathname"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+require 'pathname'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile',
+                                           Pathname.new(__FILE__).realpath)
 
-require "bundler/setup"
+require 'bundler/setup'
 
-require "webpacker"
-require "webpacker/dev_server_runner"
+require 'webpacker'
+require 'webpacker/dev_server_runner'
 
-APP_ROOT = File.expand_path("..", __dir__)
+APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   Webpacker::DevServerRunner.run(ARGV)
 end

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,17 +1,19 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
-  yarn = ENV["PATH"].split(File::PATH_SEPARATOR).
-    select { |dir| File.expand_path(dir) != __dir__ }.
-    product(["yarn", "yarn.cmd", "yarn.ps1"]).
-    map { |dir, file| File.expand_path(file, dir) }.
-    find { |file| File.executable?(file) }
+  yarn = ENV['PATH'].split(File::PATH_SEPARATOR)
+                    .reject { |dir| File.expand_path(dir) == __dir__ }
+                    .product(['yarn', 'yarn.cmd', 'yarn.ps1'])
+                    .map { |dir, file| File.expand_path(file, dir) }
+                    .find { |file| File.executable?(file) }
 
   if yarn
     exec yarn, *ARGV
   else
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    warn 'Yarn executable was not detected in the system.'
+    warn 'Download Yarn at https://yarnpkg.com/en/docs/install'
     exit 1
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,12 +1,15 @@
-require_relative "boot"
+# frozen_string_literal: true
 
-require "rails/all"
+require_relative 'boot'
+
+require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module RailsBlog
+  # Application class
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
-require_relative "application"
+require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -53,7 +55,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -88,8 +90,8 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,6 @@
-require "active_support/core_ext/integer/time"
+# frozen_string_literal: true
+
+require 'active_support/core_ext/integer/time'
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # ActiveSupport::Reloader.to_prepare do

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
@@ -5,4 +7,4 @@
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
 # by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
-Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]
+Rails.backtrace_cleaner.remove_silencers! if ENV['BACKTRACE']

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+Rails.application.config.filter_parameters += %i[
+  passw secret token _key crypt salt certificate otp ssn
 ]

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Define an application-wide HTTP permissions policy. For further
 # information see https://developers.google.com/web/updates/2018/06/feature-policy
 #

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,28 +1,30 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
-worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch('PORT', 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV', 'development')
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
-  root "articles#index"
+  root 'articles#index'
 
   resources :articles do
     resources :comments

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 Spring.watch(
-  ".ruby-version",
-  ".rbenv-vars",
-  "tmp/restart.txt",
-  "tmp/caching-dev.txt"
+  '.ruby-version',
+  '.rbenv-vars',
+  'tmp/restart.txt',
+  'tmp/caching-dev.txt'
 )

--- a/db/migrate/20211019154614_create_articles.rb
+++ b/db/migrate/20211019154614_create_articles.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# CreateArticles class
 class CreateArticles < ActiveRecord::Migration[6.1]
   def change
     create_table :articles do |t|

--- a/db/migrate/20211019215945_create_comments.rb
+++ b/db/migrate/20211019215945_create_comments.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# CreateComments class
 class CreateComments < ActiveRecord::Migration[6.1]
   def change
     create_table :comments do |t|

--- a/db/migrate/20211020160400_add_status_to_articles.rb
+++ b/db/migrate/20211020160400_add_status_to_articles.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# AddStatusToArticles class
 class AddStatusToArticles < ActiveRecord::Migration[6.1]
   def change
     add_column :articles, :status, :string

--- a/db/migrate/20211020161047_add_status_to_comments.rb
+++ b/db/migrate/20211020161047_add_status_to_comments.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# AddStatusToComments class
 class AddStatusToComments < ActiveRecord::Migration[6.1]
   def change
     add_column :comments, :status, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,28 +12,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_20_161047) do
-
+ActiveRecord::Schema.define(version: 20_211_020_161_047) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "articles", force: :cascade do |t|
-    t.string "title"
-    t.text "body"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "status"
+  create_table 'articles', force: :cascade do |t|
+    t.string 'title'
+    t.text 'body'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'status'
   end
 
-  create_table "comments", force: :cascade do |t|
-    t.string "commenter"
-    t.text "body"
-    t.bigint "article_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "status"
-    t.index ["article_id"], name: "index_comments_on_article_id"
+  create_table 'comments', force: :cascade do |t|
+    t.string 'commenter'
+    t.text 'body'
+    t.bigint 'article_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.string 'status'
+    t.index ['article_id'], name: 'index_comments_on_article_id'
   end
 
-  add_foreign_key "comments", "articles"
+  add_foreign_key 'comments', 'articles'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,11 +1,15 @@
-require "test_helper"
+# frozen_string_literal: true
 
-class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
-  # test "connects with cookies" do
-  #   cookies.signed[:user_id] = 42
-  #
-  #   connect
-  #
-  #   assert_equal connection.user_id, "42"
-  # end
+require 'test_helper'
+
+module ApplicationCable
+  class ConnectionTest < ActionCable::Connection::TestCase
+    # test "connects with cookies" do
+    #   cookies.signed[:user_id] = 42
+    #
+    #   connect
+    #
+    #   assert_equal connection.user_id, "42"
+    # end
+  end
 end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ArticlesControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ArticleTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class CommentTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,17 @@
+# frozen_string_literal: true
+
 ENV['RAILS_ENV'] ||= 'test'
-require_relative "../config/environment"
-require "rails/test_help"
+require_relative '../config/environment'
+require 'rails/test_help'
 
-class ActiveSupport::TestCase
-  # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
+module ActiveSupport
+  class TestCase
+    # Run tests in parallel with specified workers
+    parallelize(workers: :number_of_processors)
 
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  fixtures :all
+    # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+    fixtures :all
 
-  # Add more helper methods to be used by all tests here...
+    # Add more helper methods to be used by all tests here...
+  end
 end


### PR DESCRIPTION
PR related to:

- Update project files applying rubocop over app, bin, config, db and test folders.

- Update the project files by applying rubocop to the files in the project root.

- After rubocop was applied to the project, only 3 offenses remained:

1. On violations "bin/bundle:24:3: C: Metrics/CyclomaticComplexity: Cyclomatic complexity for cli_arg_version is too high. [9/7]" and "bin/bundle:24:3: C: Metrics/PerceivedComplexity: Perceived complexity for cli_arg_version is too high. [9/8]", it was reviewed and it was not found possible to reduce the cyclomatic complexity without affecting the functionality of the method.
2. On violation "bin/bundle:24:3: C: Metrics/MethodLength: Method has too many lines. [11/10]", we checked and did not find it possible to reduce the number of lines of code without violating another ruby style guide rule.

- In lb, log, node_modules, public, storage, test, temp and vendor folders it was not necessary to apply style corrections since rubocop found no infractions.
